### PR TITLE
Fix Tetris buttons forever

### DIFF
--- a/Keebcard.ino
+++ b/Keebcard.ino
@@ -52,19 +52,19 @@ void universal_setup() {
 
   // seed random number with value from the analog pin
   // it doesn't vary all that much, but it helps
-  srand(analogRead(MIDDLE_BUTTON));
+  // srand(analogRead(MIDDLE_BUTTON) + analogRead(2) + analogRead(3));
   // here's the good stuff, Entropy based off clock jitter
-  // Entropy.initialize();
+//  Entropy.initialize();
 
   pinMode(LEFT_BUTTON, INPUT);
   pinMode(RIGHT_BUTTON, INPUT);
   pinMode(MIDDLE_BUTTON, INPUT);
 
-  #ifdef SNAKE
-    oled.setMemoryAddressingMode(0); // TODO prolly don't need this
-    // no double buffering for now. very little to update so it runs fast anyways
-    oled.switchRenderFrame();
-  #endif
+#ifdef SNAKE
+  oled.setMemoryAddressingMode(0); // TODO prolly don't need this
+  // no double buffering for now. very little to update so it runs fast anyways
+  oled.switchRenderFrame();
+#endif
 }
 
 
@@ -73,41 +73,41 @@ void setup() {
   setup_game();
 }
 
-void setup_game(){
-  #ifdef TETRIS
-    GIMSK = 0b00100000;    // turns on pin change interrupts
-    PCMSK = 0b00011010;    // turn on interrupts on pins PB0, PB1, &amp;amp; PB4
-    sei();                 // enables interrupts
+void setup_game() {
+#ifdef TETRIS
+  GIMSK = 0b00100000;    // turns on pin change interrupts
+  PCMSK = 0b00011010;    // turn on interrupts on pins PB0, PB1, &amp;amp; PB4
+  sei();                 // enables interrupts
 
-    Tetris tetris(&oled);
-    gameOver(tetris.run());
-    oled.switchFrame();
-  #elif defined(CONWAY)
-    oled.setMemoryAddressingMode(0); // TODO prolly don't need this
-    Conway conway(&oled);
-    conway.run();
-  #elif defined(BUSINESS_CARD)
-    businessCard(&oled);
-  #elif defined(PONG)
-    oled.setCursor(8, 1);
-    oled.print(F("PLAYER 1 START"));
-    oled.switchFrame();
-    delay(800);
-    oled.switchFrame();
-    oled.clear();
-    oled.setMemoryAddressingMode(1);
-    Pong pong(&oled);
-    pong.run();
-  #elif defined(SNAKE)
-    oled.setCursor(8, 1);
-    oled.print(F("NOKIA OS"));
-    // oled.switchFrame();
-    delay(800);
-    // oled.switchFrame();
-    oled.clear();
-    Snake snake(&oled);
-    gameOver(snake.run());
-  #endif
+  Tetris tetris(&oled);
+  gameOver(tetris.run());
+  oled.switchFrame();
+#elif defined(CONWAY)
+  oled.setMemoryAddressingMode(0); // TODO prolly don't need this
+  Conway conway(&oled);
+  conway.run();
+#elif defined(BUSINESS_CARD)
+  businessCard(&oled);
+#elif defined(PONG)
+  oled.setCursor(8, 1);
+  oled.print(F("PLAYER 1 START"));
+  oled.switchFrame();
+  delay(800);
+  oled.switchFrame();
+  oled.clear();
+  oled.setMemoryAddressingMode(1);
+  Pong pong(&oled);
+  pong.run();
+#elif defined(SNAKE)
+  oled.setCursor(8, 1);
+  oled.print(F("NOKIA OS"));
+  // oled.switchFrame();
+  delay(800);
+  // oled.switchFrame();
+  oled.clear();
+  Snake snake(&oled);
+  gameOver(snake.run());
+#endif
 }
 
 void loop() {
@@ -120,10 +120,10 @@ void loop() {
 }
 
 void gameOver(uint32_t score) {
-    oled.clear();
-    oled.setCursor(0,0);
-    oled.print(F("Game Over!"));
-    oled.setCursor(0,2);
-    oled.print(F("Score: "));
-    oled.print(score);
+  oled.clear();
+  oled.setCursor(0, 0);
+  oled.print(F("Game Over!"));
+  oled.setCursor(0, 2);
+  oled.print(F("Score: "));
+  oled.print(score);
 }


### PR DESCRIPTION
Input on tetris has been lackluster for a while now - I thought I had fixed this, but while I was flashing the Keebcards I made for OpenSauce, I realized I had not. Half of the work before OpenSauce was dedicated to getting the buttons on Tetris to feel right - it didn't come down to much, but I tried probably 30 different schemes to reduce accidental button presses without ignoring real ones. 

Every kit sold at OpenSauce already has these changes, but if you have an older kit - or you've reflashed Tetris since - you should pull these changes down and upload a new firmware blob to the ATTiny